### PR TITLE
jwtを用いたログイン処理

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./docker/mysql/data/init:/docker-entrypoint-initdb.d
       - ./docker/mysql/data/volume:/var/lib/mysql
     environment:
-      MYSQL_DATABASE: go_dev_api
+      MYSQL_DATABASE: short_cut_master
       MYSQL_USER: ${USERNAME}
       MYSQL_PASSWORD: ${USERPASS}
       MYSQL_ROOT_PASSWORD: ${ROOTPASS}

--- a/docker/mysql/data/init/init.sql
+++ b/docker/mysql/data/init/init.sql
@@ -1,12 +1,13 @@
-CREATE DATABASE IF NOT EXISTS go_dev_api;
-USE go_dev_api;
+CREATE DATABASE IF NOT EXISTS short_cut_master;
+USE short_cut_master;
 
 CREATE TABLE IF NOT EXISTS users (
-  id          INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-  name        VARCHAR(256) NOT NULL,
-  is_admin    BOOLEAN NOT NULL DEFAULT false,
-  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  id             INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  name           VARCHAR(256) NOT NULL,
+  is_admin       BOOLEAN NOT NULL DEFAULT false,
+  google_user_id VARCHAR(256),
+  created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS quizzes (
@@ -20,15 +21,25 @@ CREATE TABLE IF NOT EXISTS quizzes (
 CREATE TABLE IF NOT EXISTS rankings (
   id          INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
   quiz_id     INT NOT NULL,
-  user_id     INT NOT NULL,
   ranking     INT NOT NULL DEFAULT 0,
   created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (quiz_id)
+    REFERENCES quizzes(id)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=INNODB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS user_rankings (
+  id             INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  user_id        INT NOT NULL,
+  ranking_id     INT NOT NULL,
+  created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   FOREIGN KEY (user_id)
     REFERENCES users(id)
     ON UPDATE CASCADE ON DELETE CASCADE,
-  FOREIGN KEY (quiz_id)
-    REFERENCES quizzes(id)
+  FOREIGN KEY (ranking_id)
+    REFERENCES rankings(id)
     ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
@@ -55,12 +66,14 @@ CREATE TABLE IF NOT EXISTS answers (
     ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=INNODB DEFAULT CHARSET=utf8;
 
-INSERT INTO users (id, name, is_admin) VALUES (1, "テストユーザー1", false),(2, "テストユーザー2", false),(3, "テストユーザー3", false), (4, "テストユーザー4", false), (5, "テスト管理者", true);
+INSERT INTO users (name, is_admin) VALUES ("テストユーザー1", false),("テストユーザー2", false),("テストユーザー3", false), ("テストユーザー4", false), ("テスト管理者", true);
 
-INSERT INTO quizzes (id, name, type) VALUES (1, "Slack", "macOS"), (2, "VSCode", "macOS"), (3, "Chrome", "macOS"), (4, "Github", "macOS");
+INSERT INTO quizzes (name, type) VALUES ("Slack", "macOS"), ("VSCode", "macOS"), ("Chrome", "macOS"), ("Github", "macOS");
 
-INSERT INTO rankings (quiz_id, user_id, ranking) VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (4, 4, 1);
+INSERT INTO rankings (quiz_id, ranking) VALUES (1, 1), (2, 1), (3, 1), (4, 1);
 
-INSERT INTO questions (id, quiz_id, contents) VALUES (1, 1, "DMを閲覧するには？");
+INSERT INTO user_rankings (ranking_id, user_id) VALUES (1, 1), (2, 1), (3, 3), (4, 4);
 
-INSERT INTO answers (id, question_id, contents, is_correct) VALUES (1, 1, "⌘+shit+↓", false), (2, 1, "⌘+shit+K", true), (3, 1, "⌘+K", false), (4, 1, "⌘+T", false);
+INSERT INTO questions (quiz_id, contents) VALUES (1, "DMを閲覧するには？");
+
+INSERT INTO answers (question_id, contents, is_correct) VALUES (1, "⌘+shit+↓", false), (1, "⌘+shit+K", true), (1, "⌘+K", false), (1, "⌘+T", false);


### PR DESCRIPTION
## 概要

- フロントから渡ってきたtokenを元にGoogleにjwt情報をリクエスト後に、jwtを用いたログイン処理を行う

## 実装方針
- jwtに含まれるuser_id（sub）を元にuserを検索し、あればそのユーザーとセッションを返す。無ければ、ユーザーを作成してセッションと共に返す。

## このPRやったこと
- [ ] audが一致しているか確認
  - https://developers.google.com/identity/sign-in/web/backend-auth
- [ ] user_id（jwtのsub）でDB検索してあればそのユーザーとセッション返す
- [ ] user_id（jwtのsub）でDB検索して無ければ作成する
- [ ] テーブルにexternal_user_idカラムを用意してuser_idを保存（hash化して保存）

* このプルリクで何をしたのか？

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## 参考資料
- https://developers.google.com/identity/sign-in/web/backend-auth

