### PR TITLE
ログアウトエンドポイントを設置

### DIFF
--- a/src/infrastructure/router.go
+++ b/src/infrastructure/router.go
@@ -15,7 +15,7 @@ type LoginRequest struct {
 
 func hello(c echo.Context) error {
 	cookie, err := c.Cookie("session")
-	_ = cookie;
+	_ = cookie
 	if err != nil {
 		if err == http.ErrNoCookie {
 			return c.String(http.StatusUnauthorized, "Cookie doesn't exist")
@@ -59,5 +59,20 @@ func Handle(e *echo.Echo) {
 		}
 
 		return c.JSON(http.StatusOK, res.UserInfo.Name)
+	})
+
+	// -- logout -- //
+	e.POST("/logout", func(c echo.Context) error {
+		sess, err := session.Get("session", c)
+		if err != nil {
+			return err
+		}
+
+		sess.Options = &sessions.Options{
+			MaxAge: -1,
+		}
+		sess.Save(c.Request(), c.Response())
+
+		return c.JSON(http.StatusOK, "logout")
 	})
 }


### PR DESCRIPTION
## 概要

ログアウトエンドポイントを設置し、ログアウト処理を行えるようにする

## このPRやったこと
- MaxAgeに負の数を指定してCookieを返却する

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## 参考資料
- MaxAgeに0または負の数値を設定すると、直ちにクッキーは期限切れになる
  - https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Set-Cookie#%E5%B1%9E%E6%80%A7

