### PR TITLE
クイズの種類ごとにQuestionsを取得できるようにする

### DIFF
--- a/docker/mysql/data/init/init.sql
+++ b/docker/mysql/data/init/init.sql
@@ -1,82 +1,115 @@
 CREATE DATABASE IF NOT EXISTS shortcut_master_db;
+
 USE shortcut_master_db;
 
 CREATE TABLE IF NOT EXISTS users (
-  id             INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-  name           VARCHAR(256) NOT NULL,
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  name VARCHAR(256) NOT NULL,
   google_user_id VARCHAR(256) NOT NULL UNIQUE,
-  email          VARCHAR(256) NOT NULL UNIQUE,
-  is_admin       BOOLEAN NOT NULL DEFAULT false,
-  created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=INNODB DEFAULT CHARSET=utf8;
+  email VARCHAR(256) NOT NULL UNIQUE,
+  is_admin BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE = INNODB DEFAULT CHARSET = utf8;
 
 CREATE TABLE IF NOT EXISTS quizzes (
-  id          INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-  name        VARCHAR(256) NOT NULL,
-  type        ENUM("macOS", "windows"),
-  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=INNODB DEFAULT CHARSET=utf8;
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  name VARCHAR(256) NOT NULL,
+  type ENUM("macOS", "windows"),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE = INNODB DEFAULT CHARSET = utf8;
 
 CREATE TABLE IF NOT EXISTS rankings (
-  id          INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-  quiz_id     INT NOT NULL,
-  user_id     INT NOT NULL,
-  ranking     INT NOT NULL DEFAULT 0,
-  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id)
-    REFERENCES users(id)
-    ON UPDATE CASCADE ON DELETE CASCADE,
-  FOREIGN KEY (quiz_id)
-    REFERENCES quizzes(id)
-    ON UPDATE CASCADE ON DELETE CASCADE
-) ENGINE=INNODB DEFAULT CHARSET=utf8;
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  quiz_id INT NOT NULL,
+  user_id INT NOT NULL,
+  ranking INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (quiz_id) REFERENCES quizzes(id) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE = INNODB DEFAULT CHARSET = utf8;
 
 CREATE TABLE IF NOT EXISTS questions (
-  id          INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-  quiz_id     INT NOT NULL,
-  contents    VARCHAR(256) NOT NULL,
-  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  FOREIGN KEY (quiz_id)
-    REFERENCES quizzes(id)
-    ON UPDATE CASCADE ON DELETE CASCADE
-) ENGINE=INNODB DEFAULT CHARSET=utf8;
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  quiz_id INT NOT NULL,
+  quiz_type VARCHAR(256) NOT NULL,
+  contents VARCHAR(256) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (quiz_id) REFERENCES quizzes(id) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE = INNODB DEFAULT CHARSET = utf8;
 
 CREATE TABLE IF NOT EXISTS answers (
-  id          INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
   question_id INT NOT NULL,
-  contents    VARCHAR(256) NOT NULL,
-  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  FOREIGN KEY (question_id)
-    REFERENCES questions(id)
-    ON UPDATE CASCADE ON DELETE CASCADE
-) ENGINE=INNODB DEFAULT CHARSET=utf8;
+  contents VARCHAR(256) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (question_id) REFERENCES questions(id) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE = INNODB DEFAULT CHARSET = utf8;
 
 CREATE TABLE IF NOT EXISTS answer_histories (
-  id          INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-  answer_id   INT NOT NULL,
-  contents    VARCHAR(256) NOT NULL,
-  is_correct  BOOLEAN NOT NULL DEFAULT false,
-  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  FOREIGN KEY (answer_id)
-    REFERENCES answers(id)
-    ON UPDATE CASCADE ON DELETE CASCADE
-) ENGINE=INNODB DEFAULT CHARSET=utf8;
+  id INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+  answer_id INT NOT NULL,
+  contents VARCHAR(256) NOT NULL,
+  is_correct BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (answer_id) REFERENCES answers(id) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE = INNODB DEFAULT CHARSET = utf8;
 
-INSERT INTO users (id, name, google_user_id, email, is_admin) VALUES (1, "テストユーザー1", 1, "test1@example.com", false),(2, "テストユーザー2", 2, "test2@example.com", false),(3, "テストユーザー3", 3, "test3@example.com", false),(4, "テストユーザー4", 4, "test4@example.com", false),(5, "テスト管理者", 5, "test5@example.com", true);
-;
+INSERT INTO
+  users (id, name, google_user_id, email, is_admin)
+VALUES
+  (1, "テストユーザー1", 1, "test1@example.com", false),
+  (2, "テストユーザー2", 2, "test2@example.com", false),
+  (3, "テストユーザー3", 3, "test3@example.com", false),
+  (4, "テストユーザー4", 4, "test4@example.com", false),
+  (5, "テスト管理者", 5, "test5@example.com", true);
 
-INSERT INTO quizzes (id, name, type) VALUES (1, "Slack", "macOS"), (2, "VSCode", "macOS"), (3, "Chrome", "macOS"), (4, "GitHub", "macOS");
+INSERT INTO
+  quizzes (id, name, type)
+VALUES
+  (1, "Slack", "macOS"),
+  (2, "VSCode", "macOS"),
+  (3, "Chrome", "macOS"),
+  (4, "GitHub", "macOS");
 
-INSERT INTO questions (id, quiz_id, contents) VALUES (1, 1, "メッセージ送信の取り消し"), (2, 1, "検索を開始する"), (3, 1, "別の会話へ移動する"), (4, 1, "履歴で前に戻る"), (5, 1, "DMを閲覧する"), (6, 1, "「後で」のアイテムを表示する"), (7, 1, "チャンネルをブラウズする"), (8, 1, "メッセージを未読にする"), (9, 1, "全未読画面を開く"), (10, 1, "スレッド画面を開く");
+INSERT INTO
+  questions (id, quiz_id, quiz_type, contents)
+VALUES
+  (1, 1, 'slack', "メッセージ送信の取り消し"),
+  (2, 1, 'slack', "検索を開始する"),
+  (3, 1, 'slack', "別の会話へ移動する"),
+  (4, 1, 'slack', "履歴で前に戻る"),
+  (5, 1, 'slack', "DMを閲覧する"),
+  (6, 1, 'slack', "「後で」のアイテムを表示する"),
+  (7, 1, 'slack', "チャンネルをブラウズする"),
+  (8, 1, 'slack', "メッセージを未読にする"),
+  (9, 1, 'slack', "全未読画面を開く"),
+  (10, 1, 'slack', "スレッド画面を開く");
 
-INSERT INTO answers (id, question_id, contents) VALUES (1, 1, "⌘+Z"), (2, 2, "⌘+G"), (3, 3, "⌘+K"), (4, 4, "⌘+["), (5, 5, "⌘+Shift+K"), (6, 6, "⌘+Shift+S"), (7, 7, "⌘+Shift+L"), (8, 8, "Option+Click"), (9, 9, "⌘+Shift+A"), (10, 10, "⌘+Shift+T");
+INSERT INTO
+  answers (id, question_id, contents)
+VALUES
+  (1, 1, "⌘+Z"),
+  (2, 2, "⌘+G"),
+  (3, 3, "⌘+K"),
+  (4, 4, "⌘+["),
+  (5, 5, "⌘+Shift+K"),
+  (6, 6, "⌘+Shift+S"),
+  (7, 7, "⌘+Shift+L"),
+  (8, 8, "Option+Click"),
+  (9, 9, "⌘+Shift+A"),
+  (10, 10, "⌘+Shift+T");
 
 -- INSERT INTO answer_histories (id, answer_id, contents, is_correct) VALUES (1, 1, "⌘+Z", true), (2, 2, "⌘+G", false), (3, 3, "⌘+K", false), (4, 4, "⌘+K", false), (5, 5, "⌘+Shift+K", false), (6, 6, "⌘+Shift+S", false), (7, 7, "⌘+Shift+L", false), (8, 8, "Option+Click", false), (9, 9, "⌘+Shift+A", false), (10, 10, "⌘+Shift+T", false);
-
-INSERT INTO rankings (quiz_id, user_id, ranking) VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (4, 4, 1);
+INSERT INTO
+  rankings (quiz_id, user_id, ranking)
+VALUES
+  (1, 1, 1),
+  (2, 2, 1),
+  (3, 3, 1),
+  (4, 4, 1);

--- a/src/domain/question.go
+++ b/src/domain/question.go
@@ -3,5 +3,6 @@ package domain
 type Question struct {
 	ID       int    `json:"id" gorm:"primary_key"`
 	QuizId   int    `json:"quiz_id"`
+	QuizType string `json:"quiz_type"`
 	Contents string `json:"contents"`
 }

--- a/src/infrastructure/router_test.go
+++ b/src/infrastructure/router_test.go
@@ -120,13 +120,13 @@ func TestQuizEndpoint(t *testing.T) {
 func TestQuestionsEndpoint(t *testing.T) {
 	e := echo.New()
 	endpoint := "/questions"
-	quiz_id := 1
+	quizType := "slack"
 
 	mockSqlHandler := &SqlHandlerMock{
 		MockFindAllByParams: func(obj interface{}, column string, params interface{}) *gorm.DB {
 			questions := obj.(*[]entity.Question)
 			*questions = []entity.Question{
-				{ID: 1, QuizId: quiz_id, Contents: "メッセージ送信の取り消し"},
+				{ID: 1, QuizType: quizType, Contents: "メッセージ送信の取り消し"},
 			}
 			return &gorm.DB{}
 		},
@@ -145,9 +145,9 @@ func TestQuestionsEndpoint(t *testing.T) {
 	}
 
 	t.Run("with session cookie", func(t *testing.T) {
-		t.Run("with quiz_id", func(t *testing.T) {
+		t.Run("with quiz_type", func(t *testing.T) {
 			e.GET(endpoint, func(c echo.Context) error {
-				questions := questionsController.GetQuestionsByQuiz(quiz_id)
+				questions := questionsController.GetQuestionsByQuiz(quizType)
 				return c.JSON(http.StatusOK, questions.Questions)
 			})
 
@@ -168,9 +168,9 @@ func TestQuestionsEndpoint(t *testing.T) {
 			assert.Len(t, questions, 1)
 			assert.Equal(t, "メッセージ送信の取り消し", questions[0].Contents)
 		})
-		t.Run("without quiz_id", func(t *testing.T) {
+		t.Run("without quiz_type", func(t *testing.T) {
 			e.GET(endpoint, func(c echo.Context) error {
-				return c.JSON(http.StatusBadRequest, "quiz_id is required")
+				return c.JSON(http.StatusBadRequest, "quiz_type is required")
 			})
 
 			cookie := &http.Cookie{

--- a/src/interfaces/controllers/question_controllers.go
+++ b/src/interfaces/controllers/question_controllers.go
@@ -25,13 +25,13 @@ func NewQuesionsController(sqlHandler repository.SqlHandler) *QuestionController
 	}
 }
 
-func (controller *QuestionController) GetQuestionsByQuiz(id int) QuestionResult {
+func (controller *QuestionController) GetQuestionsByQuiz(quizType string) QuestionResult {
 	res := QuestionResult{
 		Questions: []entity.Question{},
 		Err:       nil,
 	}
 
-	questions, err := controller.Interactor.GetQuestionsByQuiz(id)
+	questions, err := controller.Interactor.GetQuestionsByQuiz(quizType)
 
 	if err != nil {
 		res.Err = err

--- a/src/interfaces/database/question_repository.go
+++ b/src/interfaces/database/question_repository.go
@@ -18,9 +18,9 @@ func (db *QuestionRepository) Select() []entity.Question {
 	return question
 }
 
-func (db *QuestionRepository) SelectByQuiz(id int) ([]entity.Question, error) {
+func (db *QuestionRepository) SelectByQuiz(quizType string) ([]entity.Question, error) {
 	question := []entity.Question{}
-	res := db.SqlHandler.FindAllByParams(&question, "quiz_id", id)
+	res := db.SqlHandler.FindAllByParams(&question, "quiz_type", quizType)
 	if err := res.Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return []entity.Question{}, fmt.Errorf("Record not found")

--- a/src/usecases/question/question_interactor.go
+++ b/src/usecases/question/question_interactor.go
@@ -12,8 +12,8 @@ func (interactor *QuestionInteractor) GetQuestions() []entity.Question {
 	return interactor.QuestionRepository.Select()
 }
 
-func (interactor *QuestionInteractor) GetQuestionsByQuiz(id int) ([]entity.Question, error) {
-	questions, err := interactor.QuestionRepository.SelectByQuiz(id)
+func (interactor *QuestionInteractor) GetQuestionsByQuiz(quizType string) ([]entity.Question, error) {
+	questions, err := interactor.QuestionRepository.SelectByQuiz(quizType)
 	if err != nil {
 		return []entity.Question{}, err
 	}

--- a/src/usecases/question/question_repository.go
+++ b/src/usecases/question/question_repository.go
@@ -6,5 +6,5 @@ import entity "shortcut_master_api/src/domain"
 
 type QuestionRepository interface {
 	Select() []entity.Question
-	SelectByQuiz(id int) ([]entity.Question, error)
+	SelectByQuiz(quizType string) ([]entity.Question, error)
 }


### PR DESCRIPTION
## 概要
フロントエンドではクイズの種類を文字列ごとに扱っているため、クイズの種類をクエリパラメータに渡す形で検索できた方が処理の流れに一貫性があるので、そのように修正

## このPRやったこと
- [x] quiz_typeでQuestionsを検索
- [x] テストの修正

## やらないこと

## 動作確認
- [x] curlにて確認

## 参考資料


